### PR TITLE
Update semi-final results and final matchup

### DIFF
--- a/draw.html
+++ b/draw.html
@@ -151,8 +151,8 @@
                                         <div class="table-responsive">
                                               <table class="table table-striped">
                                                   <tbody>
-                                                      <tr><td class="text-center"><span class="text-danger">Polmaise B. C. (Home)</span> <strong>vs</strong> <span class="text-primary">Cambusbarron B. C. (Away)</span></td></tr>
-                                                      <tr><td class="text-center"><span class="text-danger">Causewayhead B. C. (Home)</span> <strong>vs</strong> <span class="text-primary">Stirling B. C. (Away)</span></td></tr>
+                                                      <tr><td class="text-center"><span class="text-danger">Polmaise B. C. (Home)</span> <strong>vs</strong> <span class="text-primary"><del>Cambusbarron B. C. (Away)</del></span> - Polmaise advance to the Final</td></tr>
+                                                      <tr><td class="text-center"><span class="text-danger">Causewayhead B. C. (Home)</span> <strong>vs</strong> <span class="text-primary"><del>Stirling B. C. (Away)</del></span> - Causewayhead advance to the Final</td></tr>
                                                   </tbody>
                                               </table>
                                           </div>
@@ -162,7 +162,7 @@
                                 <div class="row">
                                     <div class="col-12">
                                         <h5 class="text-center">Final - Spittalmyre B.C. - Sunday 10th August</h5>
-                                        <p class="text-center text-muted">Finalists to be determined</p>
+                                        <p class="text-center"><span class="text-primary">Polmaise B. C.</span> <strong>vs</strong> <span class="text-danger">Causewayhead B. C.</span></p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- update semi final results on draw page
- display final matchup between Polmaise and Causewayhead

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a3c7ba340832caf98b0c77dfcf722